### PR TITLE
Use shutil.which to find the npm executable instead of hardcoding it

### DIFF
--- a/django_node_assets/management/commands/npminstall.py
+++ b/django_node_assets/management/commands/npminstall.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -44,7 +45,7 @@ class Command(BaseCommand):
                 output = subprocess.check_output(
                     args=[
                         getattr(
-                            settings, 'NODE_PACKAGE_MANAGER_EXECUTABLE', '/usr/bin/npm'
+                            settings, 'NODE_PACKAGE_MANAGER_EXECUTABLE', shutil.which('npm')
                         ),
                         'install',
                         '--no-package-lock',

--- a/django_node_assets/management/commands/npminstall.py
+++ b/django_node_assets/management/commands/npminstall.py
@@ -45,7 +45,9 @@ class Command(BaseCommand):
                 output = subprocess.check_output(
                     args=[
                         getattr(
-                            settings, 'NODE_PACKAGE_MANAGER_EXECUTABLE', shutil.which('npm')
+                            settings,
+                            'NODE_PACKAGE_MANAGER_EXECUTABLE',
+                            shutil.which('npm'),
                         ),
                         'install',
                         '--no-package-lock',


### PR DESCRIPTION
I know there's a setting to override this, however then I have to keep track of another config setting. It'd be much better if we can let Python find the `npm` executable itself. 