### PR TITLE
Added mention of the ManifestNodeModulesFinder in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,16 @@ Add NodeModulesFinder to STATICFILES_FINDERS:
         'django_node_assets.finders.NodeModulesFinder',
     ]
 
+Or if you only want your direct dependencies to be collected, add ManifestNodeModulesFinder instead:
+
+.. code:: python
+
+    STATICFILES_FINDERS = [
+        'django.contrib.staticfiles.finders.FileSystemFinder',
+        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+        'django_node_assets.finders.ManifestNodeModulesFinder',
+    ]
+
 Specify absolute path to the package.json file:
 
 .. code:: python


### PR DESCRIPTION
I added the mention of the ManifestNodeModulesFinder in the README.rst to avoid devDependencies for example, in response to issue #8 .
