### PR TITLE
Add find_all to NodeModulesFinder find

### DIFF
--- a/django_node_assets/finders.py
+++ b/django_node_assets/finders.py
@@ -75,11 +75,12 @@ class NodeModulesFinder(BaseFinder):
         "node_modules",
     ]
 
-    def find(self, path, all=False):
+    def find(self, path, find_all=False, **kwargs):
+        find_all = find_all or kwargs.get("all", False)
         matches = []
         if self.storage.exists(path):
             matched_path = self.storage.path(path)
-            if not all:
+            if not find_all:
                 return matched_path
             matches.append(matched_path)
         return matches


### PR DESCRIPTION
The `all` parameter is deprecated and replaced by `find_all` as of django 5.2

Closes #11

See also
https://github.com/django/django/commit/0fdcf1029cea2d43bd68c5270f48e0f7deab5e47 https://github.com/django/django/commit/8719a6181ee6e81282822598e7f14d2d5c9b4c3c